### PR TITLE
feat!: return `FlutterApplication` on `app.start` instead of `app.started`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,20 @@ void main() async {
 
   // You can run an application from the daemon.
   // Or alternatively you can attach using `daemon.attach`
-  final application = daemon.run(
+  final application = await daemon.run(
     arguments: [
       // Any flutter arguments go here.
     ],
     workingDirectory: 'your/flutter/app/location/',
   );
 
+  // Wait until it is fully started.
+  await application.started;
 
   application.events.listen((event) {
     // Listen to events specifically emitted by this application.
   });
-
+g
   // Restart the application
   await application.restart();
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -10,11 +10,14 @@ void main(List<String> arguments) async {
   final daemon = FlutterDaemon();
   daemon.events.listen(print);
 
-  final workingDirectory = arguments.removeAt(0);
+  final workingDirectory = arguments.first;
   final application = await daemon.run(
-    arguments: arguments,
+    arguments: arguments.sublist(1),
     workingDirectory: workingDirectory,
   );
+
+  // Wait for it to be fully started.
+  await application.started;
 
   print('started');
   await Future<void>.delayed(const Duration(seconds: 10));

--- a/lib/src/flutter_application/flutter_application.dart
+++ b/lib/src/flutter_application/flutter_application.dart
@@ -35,10 +35,14 @@ class FlutterApplication {
   late final Stream<FlutterDaemonEvent> events =
       _daemon.events.where((event) => event.params['appId'] == appId);
 
-  final FlutterDaemon _daemon;
-
+  /// Resolves once the application has emitted the `app.started` event.
+  ///
+  /// If this application was created through an attach it will already be
+  /// resolved.
   Future<void> get started => _started.future;
   final Completer<void> _started;
+
+  final FlutterDaemon _daemon;
 
   /// Restarts the application.
   ///

--- a/lib/src/flutter_application/flutter_application.dart
+++ b/lib/src/flutter_application/flutter_application.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_daemon/flutter_daemon.dart';
 
 export 'requests/requests.dart';
@@ -10,7 +12,21 @@ export 'requests/requests.dart';
 /// {@endtemplate}
 class FlutterApplication {
   /// {@macro flutter_application}
-  FlutterApplication(this.appId, this._daemon);
+  FlutterApplication(this.appId, this._daemon) : _started = Completer() {
+    events
+        .firstWhere((e) => e.event == 'app.started')
+        .whenComplete(_started.complete);
+  }
+
+  /// {@macro flutter_application}
+  ///
+  /// Created when the daemon is getting attached to a running app.
+  FlutterApplication.attached(
+    this.appId,
+    this._daemon,
+  ) : _started = Completer() {
+    _started.complete();
+  }
 
   /// The application id of the attached flutter app.
   final String appId;
@@ -20,6 +36,9 @@ class FlutterApplication {
       _daemon.events.where((event) => event.params['appId'] == appId);
 
   final FlutterDaemon _daemon;
+
+  Future<void> get started => _started.future;
+  final Completer<void> _started;
 
   /// Restarts the application.
   ///

--- a/lib/src/flutter_daemon/flutter_daemon.dart
+++ b/lib/src/flutter_daemon/flutter_daemon.dart
@@ -144,8 +144,8 @@ class FlutterDaemon {
             if (data.containsKey('event')) {
               final event = FlutterDaemonEvent.fromJSON(data);
               _eventsController.add(event);
-              if (event.event == 'app.started') {
-                log('App started', level: 300);
+              if (event.event == 'app.start') {
+                log('App is attachable', level: 300);
                 completer.complete(
                   FlutterApplication(event.params['appId'] as String, this),
                 );

--- a/test/src/flutter_application/flutter_application_test.dart
+++ b/test/src/flutter_application/flutter_application_test.dart
@@ -45,6 +45,16 @@ void main() {
         });
       });
 
+      // Ensure the Flutter application get's an app.started event.
+      when(() => daemon.events).thenAnswer((_) {
+        return Stream.value(
+          FlutterDaemonEvent.fromJSON({
+            'event': 'app.started',
+            'params': {'appId': 'appId'},
+          }),
+        );
+      });
+
       application = FlutterApplication('appId', daemon);
     });
 
@@ -53,6 +63,11 @@ void main() {
       registerFallbackValue(AppRestartRequest('dummy'));
       registerFallbackValue(AppDetachRequest('dummy'));
       registerFallbackValue(AppCallServiceExtensionRequest('dummy', 'dummy'));
+    });
+
+    test('$FlutterApplication.attached resolves started directly', () {
+      final app = FlutterApplication.attached('appId', daemon);
+      expect(app.started, completes);
     });
 
     test('restart', () async {

--- a/test/src/flutter_daemon/flutter_daemon_test.dart
+++ b/test/src/flutter_daemon/flutter_daemon_test.dart
@@ -67,7 +67,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       expect(daemon.isFinished, isFalse);
       exitWith(0);
@@ -81,7 +87,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       expect(daemon.isFinished, isFalse);
       exitWith(0);
@@ -94,7 +106,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       expect(
         daemon.run(arguments: [], workingDirectory: ''),
@@ -123,7 +141,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       exitWith(0);
       await daemon.dispose();
@@ -165,7 +189,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       when(() => stdin.writeln(any())).thenAnswer((_) {
         final requests = json.decode(
@@ -201,7 +231,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       final eventFuture = daemon.events.first;
       stdout.write(
@@ -223,7 +259,13 @@ void main() {
 
       /// Emit app start event.
       await stdout.appStart();
+
+      final app = await appFuture;
       expect(await appFuture, isA<FlutterApplication>());
+
+      // Emit app started event;
+      await stdout.appStarted();
+      expect(app.started, completes);
 
       final eventFuture = daemon.events.first;
 
@@ -253,6 +295,18 @@ extension on StreamController<List<int>> {
   void write(String data) => add(utf8.encode('$data\n'));
 
   Future<void> appStart() {
+    write(
+      json.encode([
+        {
+          'event': 'app.start',
+          'params': {'appId': '0000'},
+        }
+      ]),
+    );
+    return Future.delayed(Duration.zero);
+  }
+
+  Future<void> appStarted() {
     write(
       json.encode([
         {


### PR DESCRIPTION

## Status

**READY**

## Description

Instead of waiting for the `app.started` event the daemon now wait for the `app.start` allowing the user to catch events between the start and started events. Provided a getter `started` on the `FlutterApplication` to still be able to wait for it to be fully started.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
